### PR TITLE
Adds `prefix Ident` syntax for template ADTs to match non-templated ADTs

### DIFF
--- a/grammars/edu.umn.cs.melt.exts.ableC.templateAlgebraicDataTypes/allocation/abstractsyntax/Allocate.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.templateAlgebraicDataTypes/allocation/abstractsyntax/Allocate.sv
@@ -1,9 +1,13 @@
 grammar edu:umn:cs:melt:exts:ableC:templateAlgebraicDataTypes:allocation:abstractsyntax;
 
 abstract production templateAllocateDecl
-top::Decl ::= id::Name  allocator::Name
+top::Decl ::= id::Name  allocator::Name pfx::Maybe<Name>
 {
-  top.pp = pp"template allocate datatype ${id.pp} with ${allocator.pp};";
+  top.pp =
+    case pfx of
+    | just(pfx) -> pp"template allocate datatype ${id.pp} with ${allocator.pp} prefix ${pfx.pp};"
+    | nothing() -> pp"template allocate datatype ${id.pp} with ${allocator.pp};"
+    end;
   
   local expectedAllocatorType::Type =
     functionType(
@@ -37,6 +41,11 @@ top::Decl ::= id::Name  allocator::Name
     | adtTemplateItem(params, adt) :: _ -> params
     end;
   d.allocatorName = allocator;
+  d.allocatePfx =
+    case pfx of
+    | just(pfx) -> pfx.name
+    | nothing() -> allocator.name ++ "_"
+    end;
   
   forwards to
     if !null(adtLookupErrors)

--- a/grammars/edu.umn.cs.melt.exts.ableC.templateAlgebraicDataTypes/allocation/concretesyntax/Allocate.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.templateAlgebraicDataTypes/allocation/concretesyntax/Allocate.sv
@@ -15,11 +15,12 @@ exports edu:umn:cs:melt:exts:ableC:templating:concretesyntax:templateKeyword;
 terminal Allocate_t 'allocate' lexer classes {Keyword};
 terminal Datatype_t 'datatype' lexer classes {Keyword};
 terminal With_t 'with' lexer classes {Keyword};
+terminal Prefix_t 'prefix' lexer classes {Keyword};
 
 concrete production allocateDecl_c
 -- id is Identifer_t here to avoid follow spillage
 top::Declaration_c ::= 'template' 'allocate' 'datatype' id::Identifier_t 'with' alloc::Identifier_c ';'
-{ top.ast = templateAllocateDecl(fromId(id), alloc.ast); }
+{ top.ast = templateAllocateDecl(fromId(id), alloc.ast, nothing()); }
 action {
   local constructors::Maybe<[String]> = lookupBy(stringEq, id.lexeme, adtConstructors);
   if (constructors.isJust)
@@ -27,6 +28,23 @@ action {
       addIdentsToScope(
         map(
           \ c::String -> name(alloc.ast.name ++ "_" ++ c, location=id.location),
+          constructors.fromJust),
+        TemplateIdentifier_t,
+        context);
+  -- If the datatype hasn't been declared, then do nothing
+}
+
+concrete production allocateDeclPrefix_c
+-- id is Identifer_t here to avoid follow spillage
+top::Declaration_c ::= 'template' 'allocate' 'datatype' id::Identifier_t 'with' alloc::Identifier_t 'prefix' pfx::Identifier_c ';'
+{ top.ast = templateAllocateDecl(fromId(id), fromId(alloc), just(pfx.ast)); }
+action {
+  local constructors::Maybe<[String]> = lookupBy(stringEq, id.lexeme, adtConstructors);
+  if (constructors.isJust)
+    context =
+      addIdentsToScope(
+        map(
+          \ c::String -> name(pfx.ast.name ++ c, location=id.location),
           constructors.fromJust),
         TemplateIdentifier_t,
         context);

--- a/tests/positive/e4.xc
+++ b/tests/positive/e4.xc
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+
+template<typename a>
+datatype Tree {
+  Node(Tree<a> *l, Tree<a> *r);
+  Leaf(a val);
+};
+
+template allocate datatype Tree with malloc prefix m;
+
+int main() {
+  Tree<int> *a = mNode(mLeaf(0), mLeaf(2));
+}


### PR DESCRIPTION
Same as https://github.com/melt-umn/ableC-algebraic-data-types/pull/4, for templated ADTs.